### PR TITLE
Fixes blob getting stuck in a link with an svg

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -70,7 +70,26 @@
 
     <header class="sticky top-[56px] z-10 bg-gray-900/80 backdrop-blur border-b border-gray-800">
       <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-        <h1 class="text-xl font-semibold tracking-tight">Orbly Cursor Demo</h1>
+        
+        <h1 class="text-xl font-semibold tracking-tight flex items-center gap-2">
+          <div class="w-24">
+            <a href="/" class="w-16 drop-shadow-md hover:text-white! " title="Go to homepage">
+              <svg viewBox="0 0 128 128" aria-hidden="true">
+                <path
+                  d="M66 14
+                    C94 12 118 34 116 64
+                    C114 94 90 118 62 116
+                    C34 114 12 90 14 62
+                    C16 34 38 16 66 14 Z"
+                  fill="currentColor"/>
+              </svg>
+            </a>
+          </div>
+          <span>
+            Orbly Cursor Demo
+          </span>
+        
+        </h1>
         <nav class="flex gap-4 text-sm">
           <a href="#features" class="text-gray-300 hover:text-white underline-offset-4 hover:underline">Features</a>
           <a href="#examples" class="text-gray-300 hover:text-white underline-offset-4 hover:underline">Examples</a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export function createCursor(opts: OrblyOptions = {}): OrblyAPI {
     } as OrblyAPI;
   }
 
-  let interactive = opts.interactive ?? 'a, button, [role="button"], input, textarea, select, summary, .is-interactive, [data-cursor], [data-cursor="hover"]';
+  let interactive = opts.interactive ?? 'button, [role="button"], input, textarea, select, summary, .is-interactive, [data-cursor], [data-cursor="hover"]';
   const {
     startX = window.innerWidth / 2,
     startY = window.innerHeight / 2,


### PR DESCRIPTION
This pull request introduces a minor visual enhancement to the demo page and a small change to the default interactive element selector in the cursor library. The most important changes are:

**Demo UI Improvements:**

* Added a logo SVG and homepage link to the header in `demo/index.html`, making the demo's branding more prominent and clickable.

**Cursor Library Defaults:**

* Updated the default CSS selector for interactive elements in `createCursor` (in `src/index.ts`), removing the `a` (anchor) tag from the list. This means anchor links are no longer treated as interactive by default.

Resolves #4
